### PR TITLE
Add app-wide alert system

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -5,7 +5,6 @@
 import React, { useState, useRef } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import { Tab, Paper } from '@material-ui/core'
-import { ThemeProvider } from '@material-ui/core/styles'
 import { useSelector } from 'react-redux'
 
 import VerticalTabBar from './VerticalTabBar'
@@ -16,7 +15,6 @@ import Intersect from './intersect/Intersect'
 import Account from './account/Account'
 import Matches from './matches/Matches'
 
-import { theme } from '../theme'
 import './App.css'
 
 const TRANSITION_DURATION = 500
@@ -77,37 +75,35 @@ export default function App () {
   const appRef = useRef(null)
 
   return (
-    <ThemeProvider theme={theme}>
-      <Paper className="app-root" square style={{position:'relative'}}>
-        {/* TODO: Try to make this into generic transition component */}
-        <CSSTransition
-          classNames="fade"
-          timeout={TRANSITION_DURATION}
-          unmountOnExit
-          style={{position: 'absolute', height: '100%', width: '100%'}}
-          nodeRef={loginRef}
-          in={!loggedIn}
-        >
-          <div ref={loginRef}>
-            <Login/>
-          </div>
-        </CSSTransition>
+    <Paper className="app-root" square style={{position:'relative'}}>
+      {/* TODO: Try to make this into generic transition component */}
+      <CSSTransition
+        classNames="fade"
+        timeout={TRANSITION_DURATION}
+        unmountOnExit
+        style={{position: 'absolute', height: '100%', width: '100%'}}
+        nodeRef={loginRef}
+      in={!loggedIn}
+      >
+        <div ref={loginRef}>
+          <Login/>
+        </div>
+      </CSSTransition>
 
-        <CSSTransition
-          classNames="fade"
-          timeout={TRANSITION_DURATION}
-          unmountOnExit
-          style={{position: 'absolute', height: '100%', width: '100%'}}
-          nodeRef={appRef}
-          in={loggedIn}
-        >
-          <div ref={appRef}>
-            <div style={{display: 'flex', height: '100%', width: '100%'}}>
-              {mainAppComp}
-            </div>
+      <CSSTransition
+        classNames="fade"
+        timeout={TRANSITION_DURATION}
+        unmountOnExit
+        style={{position: 'absolute', height: '100%', width: '100%'}}
+        nodeRef={appRef}
+      in={loggedIn}
+      >
+        <div ref={appRef}>
+          <div style={{display: 'flex', height: '100%', width: '100%'}}>
+            {mainAppComp}
           </div>
-        </CSSTransition>
-      </Paper>
-    </ThemeProvider>
+        </div>
+      </CSSTransition>
+    </Paper>
   );
 }

--- a/src/components/account/Login.jsx
+++ b/src/components/account/Login.jsx
@@ -7,6 +7,8 @@ import { useDispatch, useSelector } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
 import { makeStyles } from '@material-ui/core/styles'
 
+import useAlert from '../../hooks/useAlert'
+
 import {
   Button,
   Grid,
@@ -34,6 +36,8 @@ export default function Login (props) {
   const classes = useStyles()
   const dispatch = useDispatch()
 
+  const { addMessage } = useAlert()
+
   const username = useSelector(state => state.account.username)
   const [password, setPassword] = useState('')
 
@@ -41,7 +45,6 @@ export default function Login (props) {
   const [welcomeVisible, setWelcomeVisible] = useState(false)
   const [timeoutVar, setTimeoutVar] = useState(null)
 
-  const [loginErrorOpen, setLoginErrorOpen] = useState(false)
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
 
   const onLoginClick = async () => {
@@ -54,7 +57,7 @@ export default function Login (props) {
 
       .catch((e) => {
         console.log(e)
-        setLoginErrorOpen(true)
+        addMessage({text: 'Invalid username or password', severity: 'error'})
         setPassword('')
       })
   }
@@ -204,19 +207,6 @@ export default function Login (props) {
         onCancel={() => setCreateDialogOpen(false)}
         onSubmit={onCreateAccountSubmit}
       />
-      <Snackbar
-        autoHideDuration={6000}
-        open={loginErrorOpen}
-        onClose={() => setLoginErrorOpen(false)}
-        color="error"
-      >
-        <Alert
-          severity="error"
-          onClose={() => setLoginErrorOpen(false)}
-        >
-          Invalid username or password
-        </Alert>
-      </Snackbar>
     </div>
   )
 }

--- a/src/components/account/Login.jsx
+++ b/src/components/account/Login.jsx
@@ -12,11 +12,9 @@ import useAlert from '../../hooks/useAlert'
 import {
   Button,
   Grid,
-  Snackbar,
   TextField,
   Typography,
 } from '@material-ui/core'
-import { Alert } from '@material-ui/lab'
 import CreateAccountDialog from './CreateAccountDialog'
 
 import { login } from '../../server'
@@ -36,7 +34,7 @@ export default function Login (props) {
   const classes = useStyles()
   const dispatch = useDispatch()
 
-  const { addMessage } = useAlert()
+  const { addAlert } = useAlert()
 
   const username = useSelector(state => state.account.username)
   const [password, setPassword] = useState('')
@@ -57,7 +55,8 @@ export default function Login (props) {
 
       .catch((e) => {
         console.log(e)
-        addMessage({text: 'Invalid username or password', severity: 'error'})
+        addAlert({text: 'Invalid username or password',
+                  severity: 'error'})
         setPassword('')
       })
   }

--- a/src/components/account/Login.jsx
+++ b/src/components/account/Login.jsx
@@ -56,6 +56,7 @@ export default function Login (props) {
       .catch((e) => {
         console.log(e)
         addAlert({text: 'Invalid username or password',
+                  type: 'snackbar',
                   severity: 'error'})
         setPassword('')
       })

--- a/src/components/global/AlertNotification.jsx
+++ b/src/components/global/AlertNotification.jsx
@@ -1,0 +1,35 @@
+// TODO: Header comments
+
+import React, { useContext, useCallback, useState, useEffect } from 'react'
+import { AlertContext } from './AlertProvider'
+import { Snackbar } from '@material-ui/core'
+import { Alert } from '@material-ui/lab'
+
+export default function AlertNotification () {
+  const { message, removeMessage } = useContext(AlertContext)
+
+  // Tie opening to separate variable as opposed to using message itself to
+  // ensure no visual glitches when clearing message
+  const [ open, setOpen ] = useState(false)
+
+  useEffect(() => {
+    if (message) setOpen(true)
+  }, [message, setOpen])
+
+  return (
+    <Snackbar
+      autoHideDuration={6000}
+      open={open}
+      onClose={() => setOpen(false)}
+      onExited={() => removeMessage()}
+      color="error"
+    >
+      <Alert
+        severity={(message && message.severity) || 'info'}
+        onClose={() => setOpen(false)}
+      >
+        { (message && message.text) || '(No details)' }
+      </Alert>
+    </Snackbar>
+  )
+}

--- a/src/components/global/AlertNotification.jsx
+++ b/src/components/global/AlertNotification.jsx
@@ -12,10 +12,10 @@
  *   const [ addAlert ] = useAlert()
  *
  *   // addAlert will automatically call this component and display a
- *   // dismissible alert message
+ *   // dismissible alert alert
  *   addAlert({
- *     title: 'Info',
- *     message: 'Test message',
+ *     title: 'Info', // Only displayed if 'dialog' type
+ *     text: 'Test alert',
  *
  *     // Controls style of the alert
  *     // Same possible fields as Material UI's "Alert" severity:
@@ -24,6 +24,7 @@
  *
  *     // Controls how alert appears
  *     // Can be 'snackbar' or 'dialog'
+ *     // (TODO)
  *     type: 'snackbar',
  *   })
  */
@@ -34,29 +35,29 @@ import { Snackbar } from '@material-ui/core'
 import { Alert } from '@material-ui/lab'
 
 export default function AlertNotification () {
-  const { message, removeMessage } = useContext(AlertContext)
+  const { alert, removeAlert } = useContext(AlertContext)
 
-  // Tie opening to separate variable as opposed to using message itself to
-  // ensure no visual glitches when clearing message
+  // Tie opening to separate variable as opposed to using alert itself to
+  // ensure no visual glitches when clearing alert
   const [ open, setOpen ] = useState(false)
 
   useEffect(() => {
-    if (message) setOpen(true)
-  }, [message, setOpen])
+    if (alert) setOpen(true)
+  }, [alert, setOpen])
 
   return (
     <Snackbar
       autoHideDuration={6000}
       open={open}
       onClose={() => setOpen(false)}
-      onExited={() => removeMessage()}
+      onExited={() => removeAlert()}
       color="error"
     >
       <Alert
-        severity={(message && message.severity) || 'info'}
+        severity={(alert && alert.severity) || 'info'}
         onClose={() => setOpen(false)}
       >
-        { (message && message.text) || '(No details)' }
+        { (alert && alert.text) || '(No details)' }
       </Alert>
     </Snackbar>
   )

--- a/src/components/global/AlertNotification.jsx
+++ b/src/components/global/AlertNotification.jsx
@@ -1,6 +1,34 @@
-// TODO: Header comments
+/*
+ * Consumes items from the global Alert context to display an error
+ *
+ * Intended for use at the top level to be displayed throughout the program
+ * (i.e. not intended for importing outside of index.js!)
+ *
+ * Strongly referenced Medium article at:
+ * https://medium.com/yld-blog/handling-global-notifications-with-reacts-context-api-7d8135510d50
+ *
+ * Example usage for displaying alert:
+ *   import useAlert from '../hooks/userAlert'
+ *   const [ addAlert ] = useAlert()
+ *
+ *   // addAlert will automatically call this component and display a
+ *   // dismissible alert message
+ *   addAlert({
+ *     title: 'Info',
+ *     message: 'Test message',
+ *
+ *     // Controls style of the alert
+ *     // Same possible fields as Material UI's "Alert" severity:
+ *     // 'info', 'error', 'success', or 'warning'
+ *     severity: 'info',
+ *
+ *     // Controls how alert appears
+ *     // Can be 'snackbar' or 'dialog'
+ *     type: 'snackbar',
+ *   })
+ */
 
-import React, { useContext, useCallback, useState, useEffect } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 import { AlertContext } from './AlertProvider'
 import { Snackbar } from '@material-ui/core'
 import { Alert } from '@material-ui/lab'

--- a/src/components/global/AlertNotification.jsx
+++ b/src/components/global/AlertNotification.jsx
@@ -18,34 +18,50 @@
  *     text: 'Test alert',
  *
  *     // Controls style of the alert
- *     // Same possible fields as Material UI's "Alert" severity:
- *     // 'info', 'error', 'success', or 'warning'
+ *     // Options: 'info', 'error', 'success', or 'warning'
+ *     // Default: 'info'
  *     severity: 'info',
  *
  *     // Controls how alert appears
- *     // Can be 'snackbar' or 'dialog'
- *     // (TODO)
+ *     // Options: 'snackbar', 'dialog'
+ *     // Default: 'snackbar'
  *     type: 'snackbar',
  *   })
  */
 
 import React, { useContext, useState, useEffect } from 'react'
 import { AlertContext } from './AlertProvider'
-import { Snackbar } from '@material-ui/core'
-import { Alert } from '@material-ui/lab'
+
+import { Dialog, Snackbar } from '@material-ui/core'
+import { Alert, AlertTitle } from '@material-ui/lab'
+
+import { capitalize } from '../../util'
 
 export default function AlertNotification () {
   const { alert, removeAlert } = useContext(AlertContext)
 
-  // Tie opening to separate variable as opposed to using alert itself to
-  // ensure no visual glitches when clearing alert
+  // Tie opening to separate variable as opposed to using alert itself
+  // Ensures no visual glitches when clearing alert
   const [ open, setOpen ] = useState(false)
 
+  // When an alert is given, open the notification
   useEffect(() => {
     if (alert) setOpen(true)
   }, [alert, setOpen])
 
-  return (
+  // Exit early if no alert to avoid a million null checks
+  if (!alert) return <div/>
+
+  // Inject default values into alert in case they're not given
+  const severity = alert.severity || 'info'
+  const alertDefaulted = {
+    severity: severity,
+    title: alert.title || capitalize(severity),
+    text: alert.text || '(no details)',
+    type: ['dialog', 'snackbar'].includes(alert.type) ? alert.type : 'snackbar',
+  }
+
+  return alertDefaulted.type === 'snackbar' ? (
     <Snackbar
       autoHideDuration={6000}
       open={open}
@@ -54,11 +70,28 @@ export default function AlertNotification () {
       color="error"
     >
       <Alert
-        severity={(alert && alert.severity) || 'info'}
+        severity={alertDefaulted.severity}
         onClose={() => setOpen(false)}
       >
-        { (alert && alert.text) || '(No details)' }
+        { alertDefaulted.text }
       </Alert>
     </Snackbar>
+  ) : (
+    <Dialog
+      open={open}
+      onClose={() => setOpen(false)}
+      onExited={() => removeAlert()}
+      maxWidth="md"
+    >
+      <Alert
+        severity={alertDefaulted.severity}
+        onClose={() => setOpen(false)}
+      >
+        <AlertTitle>
+          { alertDefaulted.title }
+        </AlertTitle>
+        { alertDefaulted.text }
+      </Alert>
+    </Dialog>
   )
 }

--- a/src/components/global/AlertProvider.jsx
+++ b/src/components/global/AlertProvider.jsx
@@ -1,3 +1,14 @@
+/*
+ * Global React context provider, allowing for any component to import the same
+ * source data
+ *
+ * addMessage can be used anywhere for alert display
+ * message & removeMessage only intended for use in AlertNotification.jsx
+ *
+ * Use hooks/useAlert.jsx for simplified context import
+ * See components/global/AlertNotification.jsx for UI component & further usage
+ */
+
 import React, { useState, useCallback } from 'react';
 
 export const AlertContext = React.createContext({

--- a/src/components/global/AlertProvider.jsx
+++ b/src/components/global/AlertProvider.jsx
@@ -2,8 +2,8 @@
  * Global React context provider, allowing for any component to import the same
  * source data
  *
- * addMessage can be used anywhere for alert display
- * message & removeMessage only intended for use in AlertNotification.jsx
+ * addAlert can be used anywhere for alert display
+ * alert & removeAlert only intended for use in AlertNotification.jsx
  *
  * Use hooks/useAlert.jsx for simplified context import
  * See components/global/AlertNotification.jsx for UI component & further usage
@@ -12,24 +12,24 @@
 import React, { useState, useCallback } from 'react';
 
 export const AlertContext = React.createContext({
-  message: null, // { title, text, severity }
-  addMessage: () => {},
-  removeMessage: () => {},
+  alert: null, // { title, text, severity }
+  addAlert: () => {},
+  removeAlert: () => {},
 })
 
 export default function AlertProvider({ children }) {
-  const [message, setMessage] = useState(null)
+  const [alert, setAlert] = useState(null)
 
-  const addMessage = useCallback(
-      ({title, text, severity}) => setMessage({title, text, severity}),
+  const addAlert = useCallback(
+      ({title, text, severity}) => setAlert({title, text, severity}),
       []
   )
-  const removeMessage = useCallback(() => setMessage(null), [])
+  const removeAlert = useCallback(() => setAlert(null), [])
 
   const context = {
-    message,
-    addMessage,
-    removeMessage,
+    alert,
+    addAlert,
+    removeAlert,
   }
 
   return (

--- a/src/components/global/AlertProvider.jsx
+++ b/src/components/global/AlertProvider.jsx
@@ -1,0 +1,29 @@
+import React, { useState, useCallback } from 'react';
+
+export const AlertContext = React.createContext({
+  message: null, // { title, text, severity }
+  addMessage: () => {},
+  removeMessage: () => {},
+})
+
+export default function AlertProvider({ children }) {
+  const [message, setMessage] = useState(null)
+
+  const addMessage = useCallback(
+      ({title, text, severity}) => setMessage({title, text, severity}),
+      []
+  )
+  const removeMessage = useCallback(() => setMessage(null), [])
+
+  const context = {
+    message,
+    addMessage,
+    removeMessage,
+  }
+
+  return (
+    <AlertContext.Provider value={context}>
+      {children}
+    </AlertContext.Provider>
+  )
+}

--- a/src/components/global/AlertProvider.jsx
+++ b/src/components/global/AlertProvider.jsx
@@ -21,7 +21,7 @@ export default function AlertProvider({ children }) {
   const [alert, setAlert] = useState(null)
 
   const addAlert = useCallback(
-      ({title, text, severity}) => setAlert({title, text, severity}),
+      ({title, text, severity, type}) => setAlert({title, text, severity, type}),
       []
   )
   const removeAlert = useCallback(() => setAlert(null), [])

--- a/src/hooks/useAlert.jsx
+++ b/src/hooks/useAlert.jsx
@@ -9,6 +9,6 @@ import { useContext } from 'react'
 import { AlertContext } from '../components/global/AlertProvider'
 
 export default function useAlert () {
-  const { message, addMessage, removeMessage } = useContext(AlertContext)
-  return { message, addMessage, removeMessage }
+  const { alert, addAlert, removeAlert } = useContext(AlertContext)
+  return { alert, addAlert, removeAlert }
 }

--- a/src/hooks/useAlert.jsx
+++ b/src/hooks/useAlert.jsx
@@ -1,3 +1,10 @@
+/*
+ * Small hook for providing easier access to the global alert context
+ * Can then be used to display alerts from any component
+ *
+ * See components/global/AlertNofication.jsx for UI component & usage
+ */
+
 import { useContext } from 'react'
 import { AlertContext } from '../components/global/AlertProvider'
 

--- a/src/hooks/useAlert.jsx
+++ b/src/hooks/useAlert.jsx
@@ -1,0 +1,7 @@
+import { useContext } from 'react'
+import { AlertContext } from '../components/global/AlertProvider'
+
+export default function useAlert () {
+  const { message, addMessage, removeMessage } = useContext(AlertContext)
+  return { message, addMessage, removeMessage }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,14 +16,23 @@ import { Provider } from 'react-redux';
 import * as serviceWorker from './serviceWorker';
 
 import CssBaseline from '@material-ui/core/CssBaseline';
-// import theme from './theme' // TODO: put theme here
+import { ThemeProvider } from '@material-ui/core/styles'
+import theme from './theme'
+
+import AlertProvider from './components/global/AlertProvider';
+import AlertNotification from './components/global/AlertNotification';
 
 ReactDOM.render(
   <React.StrictMode>
     <CssBaseline/>
-    <Provider store={store}>
-      <App/>
-    </Provider>
+    <ThemeProvider theme={theme}>
+      <AlertProvider>
+        <Provider store={store}>
+          <App/>
+        </Provider>
+        <AlertNotification/>
+      </AlertProvider>
+    </ThemeProvider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/index.js
+++ b/src/index.js
@@ -3,22 +3,27 @@
  * Sets up any styles & preferences then displays entry UI component
  */
 
+// React dependencies & boilerplate
 import React from 'react';
 import ReactDOM from 'react-dom';
+import * as serviceWorker from './serviceWorker';
 
+// App entrypoint
+import App from './components/App';
+
+// Redux store
+import store from './store';
+import { Provider } from 'react-redux';
+
+// Style imports
 import './style/index.css';
 import './style/transitions.css';
-
-import App from './components/App';
-import store from './store';
-
-import { Provider } from 'react-redux';
-import * as serviceWorker from './serviceWorker';
 
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/core/styles'
 import theme from './theme'
 
+// Global alert handler
 import AlertProvider from './components/global/AlertProvider';
 import AlertNotification from './components/global/AlertNotification';
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -67,3 +67,4 @@ theme.getGradient = (colors, opts) => {
 }
 
 export { theme }
+export default theme

--- a/src/util.js
+++ b/src/util.js
@@ -2,6 +2,14 @@
  * File containing short utility methods for use across app
  */
 
+// e.g. capitalize('info') = 'Info'
+// e.g. capitalize('the onion') = 'The Onion'
+export const capitalize = (str) => {
+  return str.split()
+            .map(([firstLetter, ...restOfStr]) => firstLetter.toUpperCase() + restOfStr.join(''))
+            .join(' ')
+}
+
 export const getShortTime = (date) => {
   // Original format: [hour]:[minute]:[second] [timezone]
   const re = /[0-9]+:[0-9]+/


### PR DESCRIPTION
## Overview
This PR creates a global alert for use across the application. Instead of defining new logic in each dialog to show individual errors, I can now report alerts anywhere via a simple importable `addAlert(...)` method.

This can be used for positive feedback, errors, warnings, information, etc.

## Stories
- As a user, I want to see alerts/errors as they occur without needing to open a console
- As a developer, I want an easily accessible and central way of displaying errors in the UI

## Screenshots

<details><summary>Show Screenshots</summary>

### Variable modes: Snackbar or Dialog
![image](https://user-images.githubusercontent.com/32147527/107865734-cf977b80-6e37-11eb-8592-2a5701c1db8d.png)
![image](https://user-images.githubusercontent.com/32147527/107865764-1e451580-6e38-11eb-9c4e-dee857f22362.png)

### Three other "Severities"
![image](https://user-images.githubusercontent.com/32147527/107865798-59474900-6e38-11eb-9f15-87212db622d7.png)
![image](https://user-images.githubusercontent.com/32147527/107865825-8a277e00-6e38-11eb-89de-977d974105f2.png)
![image](https://user-images.githubusercontent.com/32147527/107865871-f4402300-6e38-11eb-8af9-2c624973f886.png)

</summary>
