### PR TITLE
Integrate signup UI with backend

### DIFF
--- a/src/components/account/CreateAccountDialog.jsx
+++ b/src/components/account/CreateAccountDialog.jsx
@@ -103,12 +103,17 @@ export default function EditProfileDialog(props) {
 
   const onSubmit = () => {
     signup({username, email, password,})
-      .then(() => {
+      .then((r) => {
         onSuccess && onSuccess()
       })
       .catch((e) => {
+        // TODO: Set up a globally acessible error dialog to display this
         console.error(e)
-        onFail && onFail(e)
+
+        setPassword('')
+        setPasswordRepeat('')
+        setPasswordChanged(false)
+        setPasswordRepeatChanged(false)
       })
   }
 

--- a/src/components/account/CreateAccountDialog.jsx
+++ b/src/components/account/CreateAccountDialog.jsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
+import { signup } from '../../server'
 import {
   checkValidEmail,
   checkValidPassword,
@@ -101,7 +102,14 @@ export default function EditProfileDialog(props) {
   }, [open])
 
   const onSubmit = () => {
-    onSuccess && onSuccess()
+    signup({username, email, password,})
+      .then(() => {
+        onSuccess && onSuccess()
+      })
+      .catch((e) => {
+        console.error(e)
+        onFail && onFail(e)
+      })
   }
 
   return (

--- a/src/components/account/CreateAccountDialog.jsx
+++ b/src/components/account/CreateAccountDialog.jsx
@@ -8,6 +8,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import {
   checkValidEmail,
   checkValidPassword,
+  checkValidUsername,
 } from '../../util'
 
 import {
@@ -53,21 +54,26 @@ export default function EditProfileDialog(props) {
   const {
     open,
     onCancel,
-    onSubmit,
+    onFail,
+    onSuccess,
   } = props
 
   const classes = useStyles()
+  const [ username, setUsername ] = useState('')
   const [ email, setEmail ] = useState('')
   const [ password, setPassword ] = useState('')
   const [ passwordRepeat, setPasswordRepeat ] = useState('')
 
   // Monitor if user has changed a field so we don't report errors for doing nothing
+  const [ usernameChanged, setUsernameChanged ] = useState(false)
   const [ emailChanged, setEmailChanged ] = useState(false)
   const [ passwordChanged, setPasswordChanged ] = useState(false)
   const [ passwordRepeatChanged, setPasswordRepeatChanged ] = useState(false)
 
   // Central location for field errors
   // If there's an error, should be set to error reason. Otherwise should be false
+  const usernameError = usernameChanged &&
+        (!checkValidUsername(username) && 'Username must be at least 5 letters, numbers, and/or allowed symbols')
   const emailError = emailChanged &&
         (!checkValidEmail(email) && 'Invalid email')
   const passwordError = passwordChanged &&
@@ -76,21 +82,27 @@ export default function EditProfileDialog(props) {
         (password !== passwordRepeat && 'Passwords must match')
 
   const submitButtonDisabled =
-        !email || !password || !passwordRepeat ||
-        !!emailError || !!passwordError || !!passwordRepeatError
+        !username || !email || !password || !passwordRepeat ||
+        !!usernameError || !!emailError || !!passwordError || !!passwordRepeatError
 
   // Reset any previous changes when opening
   useEffect(() => {
     if (open === true) {
+      setUsername('')
       setEmail('')
       setPassword('')
       setPasswordRepeat('')
 
+      setUsernameChanged(false)
       setEmailChanged(false)
       setPasswordChanged(false)
       setPasswordRepeatChanged(false)
     }
   }, [open])
+
+  const onSubmit = () => {
+    onSuccess && onSuccess()
+  }
 
   return (
     <FormDialog
@@ -98,7 +110,7 @@ export default function EditProfileDialog(props) {
       title="Create Account"
       submitButtonText="Create Account"
       submitButtonDisabled={submitButtonDisabled}
-      onSubmit={() => onSubmit && onSubmit({email, password})}
+      onSubmit={() => onSubmit()}
       onClose={() => onCancel && onCancel()}
       onCancel={() => onCancel && onCancel()}
     >
@@ -106,6 +118,19 @@ export default function EditProfileDialog(props) {
         Welcome to <strong>Meetify</strong>! Before you start meeting people, we
         just need some basic info...
       </Typography>
+
+      <TextField
+        className={classes.editableMargin}
+        label="Username"
+        variant="outlined"
+        error={!!usernameError}
+        helperText={usernameError}
+        fullWidth
+        required
+        value={username}
+        onChange={(e) => {setUsername(e.target.value); setUsernameChanged(true)}}
+        inputProps={{spellCheck: false}}
+      />
 
       <TextField
         className={classes.editableMargin}

--- a/src/components/account/CreateAccountDialog.jsx
+++ b/src/components/account/CreateAccountDialog.jsx
@@ -5,11 +5,14 @@
 
 import React, { useState, useEffect } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
+
 import { signup } from '../../server'
+import useAlert from '../../hooks/useAlert'
 import {
   checkValidEmail,
   checkValidPassword,
   checkValidUsername,
+  spaceCaps,
 } from '../../util'
 
 import {
@@ -55,7 +58,6 @@ export default function EditProfileDialog(props) {
   const {
     open,
     onCancel,
-    onFail,
     onSuccess,
   } = props
 
@@ -70,6 +72,8 @@ export default function EditProfileDialog(props) {
   const [ emailChanged, setEmailChanged ] = useState(false)
   const [ passwordChanged, setPasswordChanged ] = useState(false)
   const [ passwordRepeatChanged, setPasswordRepeatChanged ] = useState(false)
+
+  const { addAlert } = useAlert()
 
   // Central location for field errors
   // If there's an error, should be set to error reason. Otherwise should be false
@@ -107,13 +111,20 @@ export default function EditProfileDialog(props) {
         onSuccess && onSuccess()
       })
       .catch((e) => {
-        // TODO: Set up a globally acessible error dialog to display this
-        console.error(e)
+        addAlert({
+          text: e.message || e,
+          title: (e.name && spaceCaps(e.name)) || null,
+          type: 'dialog',
+          severity: 'error',
+        })
 
-        setPassword('')
-        setPasswordRepeat('')
-        setPasswordChanged(false)
-        setPasswordRepeatChanged(false)
+        // Don't clear password if just a connection issue
+        if (!e.name || e.name !== 'CouldNotConnect') {
+          setPassword('')
+          setPasswordRepeat('')
+          setPasswordChanged(false)
+          setPasswordRepeatChanged(false)
+        }
       })
   }
 

--- a/src/components/account/Login.jsx
+++ b/src/components/account/Login.jsx
@@ -2,7 +2,7 @@
  * UI component for the opening login screen w/ welcome animation
  */
 
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useCallback, } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
 import { makeStyles } from '@material-ui/core/styles'
@@ -82,7 +82,14 @@ export default function Login (props) {
   })
 
   const onRegisterClick = () => setCreateDialogOpen(true)
-  const onCreateAccountSubmit = (obj) => setCreateDialogOpen(false)
+  const onRegisterSuccess = useCallback(() => {
+    setCreateDialogOpen(false)
+    addAlert({
+      text: 'Account successfully created!',
+      type: 'snackbar',
+      severity: 'success',
+    })
+  }, [ addAlert, setCreateDialogOpen ])
 
   // TODO: Move these to material-ui's makeStyle syntax
   const gridItemStyle = { textAlign: 'center', paddingBottom: '10px' }
@@ -204,9 +211,8 @@ export default function Login (props) {
 
       <CreateAccountDialog
         open={createDialogOpen}
+        onSuccess={onRegisterSuccess}
         onCancel={() => setCreateDialogOpen(false)}
-        onSuccess={() => setCreateDialogOpen(false)}
-        onFail={() => setCreateDialogOpen(false)}
       />
     </div>
   )

--- a/src/components/account/Login.jsx
+++ b/src/components/account/Login.jsx
@@ -205,7 +205,8 @@ export default function Login (props) {
       <CreateAccountDialog
         open={createDialogOpen}
         onCancel={() => setCreateDialogOpen(false)}
-        onSubmit={onCreateAccountSubmit}
+        onSuccess={() => setCreateDialogOpen(false)}
+        onFail={() => setCreateDialogOpen(false)}
       />
     </div>
   )

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,12 @@
 import axios from 'axios'
 import jQuery from 'jquery'
 
+import {
+  checkValidUsername,
+  checkValidEmail,
+  checkValidPassword,
+} from './util'
+
 // Always send with credentials to ensure cookies are sent/received
 axios.defaults.withCredentials = true
 
@@ -59,6 +65,7 @@ export const getPlaylistIntersect = (userId1, userId2) => {
     })
 }
 
+// NOTE: Currently doesn't use email... should allow either in the future?
 export const login = ({ username, email, password }) => {
   const urlPath = joinUrl(SERVER_URL, ...ENDPOINTS.login)
   const dataToSend = {
@@ -78,6 +85,17 @@ export const login = ({ username, email, password }) => {
     }).catch((e) => {
       throw e
     })
+}
+
+export const signup = ({ username, email, password }) => {
+  if (!checkValidUsername(username)) throw Error (`Invalid registration username: ${email}`)
+  if (!checkValidEmail(email)) throw Error (`Invalid registration email: ${email}`)
+  if (!checkValidPassword(password)) throw Error (`Invalid registration email`)
+
+  const defaultDisplayName = email.split('@')[0]
+  console.log(defaultDisplayName)
+
+  return new Promise((resolve) => resolve())
 }
 
 // TODO: Test db here to actually apply changes

--- a/src/server.js
+++ b/src/server.js
@@ -19,7 +19,8 @@ axios.defaults.withCredentials = true
 const SERVER_URL = 'http://localhost:8000'
 
 const ENDPOINTS = {
-  login: ['user', 'login']
+  login: ['user', 'login'],
+  signup: ['user', 'signup'],
 }
 
 // Nabs any cookie (that's not http-only) from the browser
@@ -66,7 +67,7 @@ export const getPlaylistIntersect = (userId1, userId2) => {
 }
 
 // NOTE: Currently doesn't use email... should allow either in the future?
-export const login = ({ username, email, password }) => {
+export const login = async ({ username, email, password }) => {
   const urlPath = joinUrl(SERVER_URL, ...ENDPOINTS.login)
   const dataToSend = {
     Username: username,
@@ -87,15 +88,34 @@ export const login = ({ username, email, password }) => {
     })
 }
 
-export const signup = ({ username, email, password }) => {
+export const signup = async ({ username, email, password }) => {
   if (!checkValidUsername(username)) throw Error (`Invalid registration username: ${email}`)
   if (!checkValidEmail(email)) throw Error (`Invalid registration email: ${email}`)
   if (!checkValidPassword(password)) throw Error (`Invalid registration email`)
 
+  const urlPath = joinUrl(SERVER_URL, ...ENDPOINTS.signup)
   const defaultDisplayName = email.split('@')[0]
-  console.log(defaultDisplayName)
 
-  return new Promise((resolve) => resolve())
+  const dataToSend = {
+    Username: username,
+    Email: email,
+    Password: password,
+    DisplayName: defaultDisplayName,
+    ZipCode: null,
+    ProfilePic: null,
+  }
+
+  return axios.post(urlPath, dataToSend)
+    .then(async (r) => {
+      console.log(r)
+    }).catch((e) => {
+      if (e.response) {
+        if (e.response.status === 409) {
+          throw Error('Could not create account: That username is already taken!')
+        }
+      }
+      throw e
+    })
 }
 
 // TODO: Test db here to actually apply changes

--- a/src/server.js
+++ b/src/server.js
@@ -106,15 +106,19 @@ export const signup = async ({ username, email, password }) => {
   }
 
   return axios.post(urlPath, dataToSend)
-    .then(async (r) => {
-      console.log(r)
-    }).catch((e) => {
-      if (e.response) {
-        if (e.response.status === 409) {
+    .catch((e) => {
+      if (e.hasOwnProperty('response')) {
+        if (!e.response) {
+          const newErr = Error('Please check your connection and try again.')
+          newErr.name = 'CouldNotConnect'
+          throw newErr
+
+        } else if (e.response.status === 409) {
           throw Error('Could not create account: That username is already taken!')
         }
+      } else {
+        throw e
       }
-      throw e
     })
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -10,6 +10,11 @@ export const capitalize = (str) => {
             .join(' ')
 }
 
+// e.g. spaceCaps('HeyThere') = 'Hey There'
+export const spaceCaps = (str) => {
+  return str.match(/[A-Z][a-z]+/g).join(' ')
+}
+
 export const getShortTime = (date) => {
   // Original format: [hour]:[minute]:[second] [timezone]
   const re = /[0-9]+:[0-9]+/

--- a/src/util.js
+++ b/src/util.js
@@ -39,7 +39,16 @@ export const checkValidEmail = (email) => {
 // True if valid password
 // Do NOT check for symbols; UI should instead encourage long passwords
 export const checkValidPassword = (password) => {
-  const re = /(.){10,}$/
+  // TODO: Make lengths universal in central config doc
+  const re = /(.){10,128}$/
+  return re.test(password)
+}
+
+// True if valid username
+// Username considered valid if uses at least 5 letters, numbers, -, ., and/or _
+export const checkValidUsername = (username) => {
   // TODO: Make max lengths universal in central config doc
-  return re.test(password) && password.length <= 128
+  // TODO: Run different regexes and return exact error from here?
+  const re = /^([a-zA-Z0-9\-_.])*$/
+  return re.test(username) && username.length >= 5 && username.length <= 128
 }


### PR DESCRIPTION
## Overview

This PR integrates the UI signup process with the back-end, meaning you should be able to create an account, have it set on the database, and immediately login with it.

This PR also adds the necessary username field for registration.

## More details

- **On success**: Display snackbar and redirect to login screen
- **On fail**: Display error dialog and stay on registration screen for a re-attempt

Expected errors:

- **No response**: Connection error
- **409**: Duplicate username

## Related Tickets

- Closes #5
- Closes [this main repo ticket](https://github.com/RobBoeckermann/Meetify/issues/13)