### PR TITLE
#23 - Add default text to profile description when user doesn't have one set

### DIFF
--- a/src/components/account/accountSlice.jsx
+++ b/src/components/account/accountSlice.jsx
@@ -23,7 +23,7 @@ export const accountSlice = createSlice({
     username: '',
     profile: {
       displayName: '',
-      description: '',
+      description: 'Your profile description',
       status: '',
       profilePicUrl: '',
     }


### PR DESCRIPTION
I added "Your Profile Description" as a default profile description.

