### PR TITLE
Integrate chat with back-end

### DIFF
--- a/src/components/account/Account.jsx
+++ b/src/components/account/Account.jsx
@@ -17,7 +17,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import useAlert from '../../hooks/useAlert'
 
 import { setProfile } from './accountSlice'
-import { getProfile, editProfile } from '../../server'
+import { editProfile } from '../../server'
 
 import {
   Button,

--- a/src/components/matches/MatchesView.jsx
+++ b/src/components/matches/MatchesView.jsx
@@ -13,7 +13,6 @@
  */
 
 import React, { useState } from 'react'
-// import { useSelector, useDispatch } from 'react-redux'
 import { makeStyles } from '@material-ui/core/styles'
 
 import {
@@ -72,28 +71,32 @@ export default function MatchesView (props) {
     onRefreshClick,
     onCloseClick,
     loading,
+    refreshMethod,
   } = props
 
-  const [ selectedUser, selectUser ] = useState(null)
   const [ selectedTab, selectTab ] = useState(null)
 
-  const onChatClick =({user}) => {
+  // Tie the selected user to an index to ensure reactivity if that item changes
+  const [ selectedUserIndex, selectUserIndex ] = useState(null)
+  const selectedUser = selectedUserIndex != null ? matches[selectedUserIndex] : null
+
+  const onChatClick =(index) => {
     selectTab('chat')
-    selectUser(user)
+    selectUserIndex(index)
   }
-  const onAddClick = ({user}) => {
+  const onAddClick = (index) => {
     console.log('Adding!')
   }
-  const onProfileClick =({user}) => {
+  const onProfileClick =(index) => {
     selectTab('profile')
-    selectUser(user)
+    selectUserIndex(index)
   }
-  const onSongsClick = ({user}) => {
+  const onSongsClick = (index) => {
     selectTab('songs')
-    selectUser(user)
+    selectUserIndex(index)
   }
   const closeUserView = () => {
-    selectUser(null)
+    selectUserIndex(null)
   }
 
   const userTiles = !matches || matches.length === 0
@@ -107,10 +110,10 @@ export default function MatchesView (props) {
             key={i}
             className={classes.card}
             user={user}
-            onActionClick={() => inMeetMode ? onAddClick({user}) : onChatClick({user})}
-            onProfileClick={() => onProfileClick({user})}
-            onCloseClick={() => onCloseClick && onCloseClick({user})}
-            onSongsClick={() => onSongsClick({user})}
+            onActionClick={() => inMeetMode ? onAddClick(i) : onChatClick(i)}
+            onProfileClick={() => onProfileClick(i)}
+            onCloseClick={() => onCloseClick && onCloseClick(i)}
+            onSongsClick={() => onSongsClick(i)}
             actionButtonIcon={inMeetMode ? <PersonAddIcon/> : <ChatIcon/>}
           />
         ))
@@ -122,6 +125,7 @@ export default function MatchesView (props) {
         user={selectedUser}
         defaultTab={selectedTab}
         chatHidden={inMeetMode}
+        refreshMethod={refreshMethod}
       />
     </div>
   )

--- a/src/components/matches/matchesSlice.jsx
+++ b/src/components/matches/matchesSlice.jsx
@@ -21,9 +21,13 @@ const matchesSlice = createSlice({
     clearMatches: state => {
       state.matches = []
     },
+    setMessages: (state, action) => {
+      const { matchId, messages } = action.payload
+      state.matches = state.matches.map((m) => m.matchId !== matchId ? m : {...m, messages})
+    },
   }
 })
 
 export { matchesSlice }
-export const { setMatches, clearMatches } = matchesSlice.actions
+export const { setMatches, clearMatches, setMessages } = matchesSlice.actions
 export default matchesSlice.reducer

--- a/src/components/meet/Meet.jsx
+++ b/src/components/meet/Meet.jsx
@@ -63,7 +63,7 @@ export default function Meet () {
 
   let timeout = null
 
-  useEffect(() => (clearTimeout(timeout)))
+  useEffect(() => (() => { clearTimeout(timeout) }))
 
   function onRefreshClick () {
     // Change UI to indicate loading

--- a/src/components/user/chat/ChatInput.jsx
+++ b/src/components/user/chat/ChatInput.jsx
@@ -8,8 +8,8 @@
  */
 
 import React, { useCallback, useState } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
 import { makeStyles } from '@material-ui/core/styles'
+import useAlert from '../../../hooks/useAlert'
 
 import { sendMessage } from '../../../server'
 
@@ -31,8 +31,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function ChatInput (props) {
   const classes = useStyles()
-  const dispatch = useDispatch()
-  const userFrom = useSelector(state => state.account.username)
+  const { addAlert } = useAlert()
 
   // NOTE: This may be causing too many re-renders? But unsure how to mitigate
   //       Doesn't appear to severely impact performance, given small component
@@ -47,18 +46,19 @@ export default function ChatInput (props) {
     // TODO: Loading icons and things
 
     // Send message to server
-    sendMessage({
-      userFrom,
-      userTo,
-      date: Date.now(),
-      text: text,
-    })
-    // Reload messages from server to ensure we're seeing it properly
-      // .then(() => dispatch(loadMatches()))
-      .finally(() => {
+    sendMessage({userTo, text})
+      .then(() => {
         setText('')
       })
-  }, [dispatch, userTo, userFrom])
+      .catch((e) => {
+        console.error(e)
+        addAlert({
+          type: 'snackbar',
+          severity: 'error',
+          text: 'Could not send message. Please try again.'
+        })
+      })
+  }, [userTo, addAlert])
 
   return (
     <div className={classes.root}>
@@ -75,7 +75,7 @@ export default function ChatInput (props) {
 
       {/* Wrap in div so button doesn't grow in height */}
       <div>
-        <IconButton onClick={onSendClick}>
+        <IconButton onClick={() => onSendClick(text)}>
           <SendIcon/>
         </IconButton>
       </div>

--- a/src/components/user/chat/ChatView.jsx
+++ b/src/components/user/chat/ChatView.jsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
     height: '100%',
     flexDirection: 'column',
     overflow: 'auto', // TODO: Make scrollbar look prettier?
-    marginBottom: theme.spacing(1)
+    marginBottom: theme.spacing(1),
   },
   chat: {
     display: 'flex',
@@ -52,19 +52,25 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
+// TODO: Fix up scrolling
 export default function ChatView (props) {
   const classes = useStyles()
+
   const {
     otherUser,
   } = props
 
-  const { messages } = otherUser
+  const {
+    messages,
+    profile,
+    userId,
+  } = otherUser
 
-  const otherUserFirstName = otherUser.profile.displayName.split(' ')[0]
+  const otherUserFirstName = profile && profile.displayName ? profile.displayName.split(' ')[0] : 'Matched User'
   const inputPlaceholder = `Message ${otherUserFirstName}`
 
   const chats = (messages || []).map((m, i) => {
-    const otherUserSent = m.sender === otherUser.username
+    const otherUserSent = m.senderUserId === userId
     const directionClass = otherUserSent ? classes.chatLeft : classes.chatRight
     const color = otherUserSent ? 'secondary' : 'primary'
 
@@ -88,7 +94,7 @@ export default function ChatView (props) {
       <div className={classes.inputContainer}>
         <ChatInput
           placeholder={inputPlaceholder}
-          userTo={otherUser.username}
+          userTo={userId}
         />
       </div>
       <div className={classes.chatContainer}>


### PR DESCRIPTION
## Overview
This integrates the individual user chats (accessible via the Meet page) with the server.

This relies on [this main repo PR](https://github.com/RobBoeckermann/Meetify/pull/40) being merged, especially due to **breaking CSRF changes** that were required from both ends for `POST` methods to work appropriately.

### Other Important Notes
- To remain efficient, **user chats are only loaded when the matched user's details are open**
    - This ensures that having a *lot* of matches will not ridiculously slow down your system when retrieving matches
    - Pings the "Get messages" endpoint roughly every second to ensure we're up-to-date
- **Calling "Get messages" so often may cause unnecessary slowness in the future**
    - Reported to [this main repo issue](https://github.com/RobBoeckermann/Meetify/issues/46)
    - Say the user has 10,000 messages, then we would load all 10,000 each second, possibly overworking the server
    - Could remedy this via:
        - Only returning most recent X messages at a time and lazy-loading as we scroll *(industry-standard, but difficult)*
        - Limiting the number of total messages two users can have *(easy, but could restrict user experience)*

## Issues
- Made #29 visible
- Made [this main repo issue](https://github.com/RobBoeckermann/Meetify/issues/46) visible
- Closes #26 