### PR TITLE
Integrate logout with the server

### DIFF
--- a/src/components/AppTabBar.jsx
+++ b/src/components/AppTabBar.jsx
@@ -15,6 +15,7 @@ import {
 } from '@material-ui/core'
 import ErrorBadge from './ErrorBadge'
 import LinkSpotifyDialog from './account/LinkSpotifyDialog'
+import LogoutDialog from './account/LogoutDialog'
 
 import LogoutIcon from '@material-ui/icons/ExitToApp'
 import AccountIcon from '@material-ui/icons/AccountCircle'
@@ -55,6 +56,7 @@ export default function VerticalTabBar (props) {
 
   const spotifyLinked = useSelector(state => state.account.spotify.linked)
   const [ linkSpotifyDialogOpen, setLinkSpotifyDialogOpen ] = useState(false)
+  const [ logoutDialogOpen, setLogoutDialogOpen ] = useState(false)
 
   const onSpotifyClick = () => {
     if (!spotifyLinked) {
@@ -80,6 +82,22 @@ export default function VerticalTabBar (props) {
     setLinkSpotifyDialogOpen(false)
   }
 
+  const onLogoutClick = () => {
+    setLogoutDialogOpen(true)
+  }
+
+  const onLogoutCancel = () => {
+    setLogoutDialogOpen(false)
+  }
+  const onLogoutSuccess = () => {
+    setLogoutDialogOpen(false)
+    addAlert({
+      severity: 'success',
+      text: 'You are now logged out from Meetify.',
+      type: 'snackbar',
+    })
+  }
+
   return (
     <>
       <Paper
@@ -97,7 +115,12 @@ export default function VerticalTabBar (props) {
         <div><hr className={classes.divider}/></div>
 
         <div className={classes.buttons}>
-          <IconButton className={classes.logoutButton}><LogoutIcon/></IconButton>
+          <IconButton
+            className={classes.logoutButton}
+            onClick={onLogoutClick}
+          >
+            <LogoutIcon/>
+          </IconButton>
 
           <IconButton onClick={onSpotifyClick}>
             <ErrorBadge
@@ -116,6 +139,11 @@ export default function VerticalTabBar (props) {
         open={linkSpotifyDialogOpen}
         onSuccess={onLinkSpotifySuccess}
         onCancel={onLinkSpotifyCancel}
+      />
+      <LogoutDialog
+        open={logoutDialogOpen}
+        onSuccess={onLogoutSuccess}
+        onCancel={onLogoutCancel}
       />
     </>
   );

--- a/src/components/account/LogoutDialog.jsx
+++ b/src/components/account/LogoutDialog.jsx
@@ -1,0 +1,60 @@
+/*
+ * Form dialog for handling account logout
+ * Sends actions directly to store
+ */
+import React from 'react'
+import { useDispatch } from 'react-redux'
+import useAlert from '../../hooks/useAlert'
+
+import { logout } from '../../server'
+import { setLoggedIn } from './accountSlice'
+
+import {
+  // Button,
+  // CircularProgress,
+  Typography,
+} from '@material-ui/core'
+import FormDialog from '../FormDialog'
+
+export default function LogoutDialog (props) {
+  const dispatch = useDispatch()
+  const { addAlert } = useAlert()
+
+  const {
+    open,
+    onCancel,
+    onSuccess,
+  } = props
+
+  const onSubmit = () => {
+    console.log('submitting')
+    logout()
+      .then(() => {
+        dispatch(setLoggedIn(false))
+        onSuccess && onSuccess()
+      })
+      .catch((e) => {
+        console.error(e)
+        addAlert({
+          type: 'snackbar',
+          severity: 'error',
+          text: 'Could not log out. Please try again.'
+        })
+      })
+  }
+
+  return (
+    <FormDialog
+      open={open}
+      title="Account Logout"
+      submitButtonText="Logout"
+      onSubmit={onSubmit}
+      onClose={() => { onCancel && onCancel() }}
+      onCancel={() => { onCancel && onCancel() }}
+    >
+      <Typography variant="body1">
+        Are you sure you want to log out?
+      </Typography>
+    </FormDialog>
+  )
+}

--- a/src/components/account/LogoutDialog.jsx
+++ b/src/components/account/LogoutDialog.jsx
@@ -7,7 +7,10 @@ import { useDispatch } from 'react-redux'
 import useAlert from '../../hooks/useAlert'
 
 import { logout } from '../../server'
-import { setLoggedIn } from './accountSlice'
+import { setLoggedIn, resetAccountData } from './accountSlice'
+import { resetIntersectData } from '../intersect/intersectSlice'
+import { resetMatchesData } from '../matches/matchesSlice'
+import { clearMatches as resetMeetData } from '../meet/meetSlice'
 
 import {
   // Button,
@@ -31,6 +34,12 @@ export default function LogoutDialog (props) {
     logout()
       .then(() => {
         dispatch(setLoggedIn(false))
+
+        dispatch(resetAccountData())
+        dispatch(resetIntersectData())
+        dispatch(resetMatchesData())
+        dispatch(resetMeetData())
+
         onSuccess && onSuccess()
       })
       .catch((e) => {

--- a/src/components/account/accountSlice.jsx
+++ b/src/components/account/accountSlice.jsx
@@ -1,20 +1,11 @@
 /*
  * Redux slice for containing current user account data
  * Should be only written to within the Login component
- * (NOTE: Currently just uses test data)
  *
  * Sends to state.account
  */
 
 import { createSlice } from '@reduxjs/toolkit'
-
-// Temporary test data for the profile
-const PROFILE_TEST_INFO = {
-  displayName: 'Doug Douglas',
-  description: 'Hey! The name\'s Doug, but you can call be "D-D-D-Doug in da Hiz House". Please talk to me. '.repeat(10),
-  status: 'Chillin\'',
-  profilePicUrl: 'https://www.kindpng.com/picc/m/78-785827_user-profile-avatar-login-account-male-user-icon.png',
-}
 
 const defaultData = {
   loggedIn: false,
@@ -50,21 +41,12 @@ export const accountSlice = createSlice({
     },
     setUsername: (state, action) => {
       state.username = action.payload
-      // TODO: Pull info from server based on username
-      //       (which should probably be async)
-      state.profile = {...PROFILE_TEST_INFO}
     },
     setUserId: (state, action) => {
       state.userId = action.payload
     },
     setProfile: (state, action) => {
       state.profile = action.payload
-    },
-    editProfile: (state, action) => {
-      // TODO: Send to server and receive again
-      const { changes } = action.payload
-      state.profile = { ...state.profile, ...changes }
-      console.log(state.profile)
     },
     setSpotifyLinked: (state, action) => {
       state.spotify.linked = action.payload
@@ -76,7 +58,6 @@ export const {
   setLoggedIn,
   setUsername,
   setUserId,
-  editProfile,
   setProfile,
   setSpotifyLinked,
 } = accountSlice.actions

--- a/src/components/account/accountSlice.jsx
+++ b/src/components/account/accountSlice.jsx
@@ -16,24 +16,37 @@ const PROFILE_TEST_INFO = {
   profilePicUrl: 'https://www.kindpng.com/picc/m/78-785827_user-profile-avatar-login-account-male-user-icon.png',
 }
 
+const defaultData = {
+  loggedIn: false,
+  username: '',
+  userId: -1,
+  spotify: {
+    linked: false,
+  },
+  profile: {
+    displayName: '',
+    description: '',
+    profilePicUrl: '',
+  },
+}
+
 export const accountSlice = createSlice({
   name: 'account',
   initialState: {
-    loggedIn: false,
-    username: '',
-    userId: -1,
-    spotify: {
-      linked: false,
-    },
-    profile: {
-      displayName: '',
-      description: '',
-      profilePicUrl: '',
-    }
+    ...defaultData,
+    spotify: { ...defaultData.spotify },
+    profile: { ...defaultData.profile },
   },
   reducers: {
     setLoggedIn: (state, action) => {
       state.loggedIn = action.payload
+
+      // If we just logged out, reset all data to defaults
+      if (!action.payload) state = {
+        ...defaultData,
+        spotify: { ...defaultData.spotify },
+        profile: { ...defaultData.profile },
+      }
     },
     setUsername: (state, action) => {
       state.username = action.payload

--- a/src/components/account/accountSlice.jsx
+++ b/src/components/account/accountSlice.jsx
@@ -7,7 +7,7 @@
 
 import { createSlice } from '@reduxjs/toolkit'
 
-const defaultData = {
+const DEFAULT_DATA = {
   loggedIn: false,
   username: '',
   userId: -1,
@@ -24,20 +24,13 @@ const defaultData = {
 export const accountSlice = createSlice({
   name: 'account',
   initialState: {
-    ...defaultData,
-    spotify: { ...defaultData.spotify },
-    profile: { ...defaultData.profile },
+    ...DEFAULT_DATA,
+    spotify: { ...DEFAULT_DATA.spotify },
+    profile: { ...DEFAULT_DATA.profile },
   },
   reducers: {
     setLoggedIn: (state, action) => {
       state.loggedIn = action.payload
-
-      // If we just logged out, reset all data to defaults
-      if (!action.payload) state = {
-        ...defaultData,
-        spotify: { ...defaultData.spotify },
-        profile: { ...defaultData.profile },
-      }
     },
     setUsername: (state, action) => {
       state.username = action.payload
@@ -51,6 +44,13 @@ export const accountSlice = createSlice({
     setSpotifyLinked: (state, action) => {
       state.spotify.linked = action.payload
     },
+    resetAccountData: (state, action) => {
+      state = {
+        ...DEFAULT_DATA,
+        spotify: { ...DEFAULT_DATA.spotify },
+        profile: { ...DEFAULT_DATA.profile },
+      }
+    }
   }
 })
 
@@ -60,5 +60,6 @@ export const {
   setUserId,
   setProfile,
   setSpotifyLinked,
+  resetAccountData,
 } = accountSlice.actions
 export default accountSlice.reducer

--- a/src/components/intersect/intersectSlice.jsx
+++ b/src/components/intersect/intersectSlice.jsx
@@ -67,9 +67,12 @@ export const intersectSlice = createSlice({
       state.songs = TEST_SONG_DATA
         .concat(TEST_SONG_DATA)
         .concat(TEST_SONG_DATA)
+    },
+    resetIntersectData: state => {
+      state = { userId: '', songs: [] }
     }
   }
 })
 
-export const { setUserId, setSongs, importSongs } = intersectSlice.actions
+export const { setUserId, setSongs, importSongs, resetIntersectData } = intersectSlice.actions
 export default intersectSlice.reducer

--- a/src/components/matches/matchesSlice.jsx
+++ b/src/components/matches/matchesSlice.jsx
@@ -25,9 +25,12 @@ const matchesSlice = createSlice({
       const { matchId, messages } = action.payload
       state.matches = state.matches.map((m) => m.matchId !== matchId ? m : {...m, messages})
     },
+    resetMatchesData: state => {
+      state.matches = []
+    },
   }
 })
 
 export { matchesSlice }
-export const { setMatches, clearMatches, setMessages } = matchesSlice.actions
+export const { setMatches, clearMatches, setMessages, resetMatchesData } = matchesSlice.actions
 export default matchesSlice.reducer

--- a/src/server.js
+++ b/src/server.js
@@ -197,7 +197,6 @@ export const editProfile = async({ userId, changes }) => {
 
   return axios.post(urlPath, dataToSend)
     .then((r) => {
-      console.log(r)
       if (r.status >= 300)
         throw Error(`Received status ${r.status} from server`)
       else if (!r.data)

--- a/src/server.js
+++ b/src/server.js
@@ -24,6 +24,7 @@ const SERVER_URL = 'http://localhost:8000'
 
 const ENDPOINTS = {
   login: ['user', 'login'],
+  logout: ['user', 'logout'],
   signup: ['user', 'signup'],
   profile: ['user', '{id}', 'profile'],
   linkSpotifyAccount: ['user', 'link-account'],
@@ -104,6 +105,20 @@ export const login = async ({ username, email, password }) => {
         username: r.data.username,
         userId: r.data.id,
       }
+    }).catch((e) => {
+      throw e
+    })
+}
+
+export const logout = async () => {
+  const urlPath = joinUrl(SERVER_URL, ...ENDPOINTS.logout)
+
+  return axios.get(urlPath)
+    .then(async (r) => {
+      if (r.status === 204)
+        return
+      else
+        throw Error(`Received status ${r.status} from server`)
     }).catch((e) => {
       throw e
     })


### PR DESCRIPTION
## Overview

This integrates logout with the server. When clicking the logout icon button in the bottom left of the app, a confirmation dialog is opened. Once confirmed, this results in:

- Ending a user session on server
- Clearing all temporary data stored in the UI (matches, profile, etc.)
- Returning the app to the login screen

Additionally, some deprecated test data was found in the account data management area, so that was cleaned up in its own commit.

## Issues

- Brought #31 to light
- Closes #15 