### PR TITLE
Allow newlines in chat messages

### DIFF
--- a/src/components/user/chat/ChatBubble.jsx
+++ b/src/components/user/chat/ChatBubble.jsx
@@ -31,7 +31,10 @@ const useStyles = makeStyles((theme) => ({
   secondaryColor: {
     backgroundColor: theme.palette.background.default
   },
-  timeText: {
+  text: {
+    whiteSpace: 'pre', // Allow new lines
+  },
+  date: {
     color: theme.palette.text.hint
   },
 }))
@@ -53,12 +56,12 @@ export default function ChatBubble (props) {
   return (
     <Paper className={`${classes.root} ${colorClass}`} elevation={1}>
       <div>
-        <Typography variant="body2">
+        <Typography variant="body2" className={classes.text}>
           {text}
         </Typography>
       </div>
       <div>
-        <Typography variant="caption" className={classes.timeText}>
+        <Typography variant="caption" className={classes.date}>
           {getShortDateTime(date)}
         </Typography>
       </div>

--- a/src/server.js
+++ b/src/server.js
@@ -355,7 +355,8 @@ export const getMessages = ({ matchId }) => {
       else return r.data.map(m => ({
         matchId: m['MatchId'],
         senderUserId: m['SenderUserId'],
-        text: m['Text'],
+        // Stored as plain-text encoding on server; convert to real new-lines
+        text: m['Text'].replaceAll('\\n', '\n'),
         date: new Date(m['META_StartDate']),
       }))
     })


### PR DESCRIPTION
Previously, when sending newlines, they were not captured when sending and displaying messages. This was due to both the server *and* the front-end implementation.

Now, the back-end escapes any newline characters to `\n` (from [this main repo PR](https://github.com/RobBoeckermann/Meetify/pull/48), which the front-end re-converts to newline characters for display in the app (also enabled by a slight CSS change).

Not necessarily dependent on [the main repo PR](https://github.com/RobBoeckermann/Meetify/pull/48), but we should probably merge them together anyway.

Closes #29 