### PR TITLE
Add ease-of-use changes to login and chat

### DIFF
--- a/src/components/ButtonProgress.jsx
+++ b/src/components/ButtonProgress.jsx
@@ -1,0 +1,18 @@
+/*
+ * A basic wrapper to material ui's CircularProgress
+ * Intended for centralized style for use in buttons when they are loading
+ */
+
+import React from 'react'
+import {
+  CircularProgress
+} from '@material-ui/core'
+
+export default function ButtonProgress (props) {
+  return (
+    <CircularProgress
+      size={24}
+      thickness={4.6}
+    />
+  )
+}

--- a/src/components/RefreshButton.jsx
+++ b/src/components/RefreshButton.jsx
@@ -2,10 +2,10 @@ import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 
 import {
-  CircularProgress,
   IconButton,
 } from '@material-ui/core'
 import RefreshIcon from '@material-ui/icons/Refresh'
+import ButtonProgress from './ButtonProgress'
 
 // TODO: De-couple with each other, centering progress on button
 const useStyles = makeStyles((theme) => ({
@@ -22,11 +22,9 @@ export default function RefreshButton (props) {
   const { loading, ...buttonProps} = props
 
   const activeComp = (loading && (
-    <CircularProgress
-      className={classes.progress}
-      size={24}
-      thickness={4.6}
-    />
+    <div className={classes.progress}>
+      <ButtonProgress/>
+    </div>
   )) || (
     <IconButton
       aria-label="refresh"

--- a/src/components/account/Login.jsx
+++ b/src/components/account/Login.jsx
@@ -15,7 +15,9 @@ import {
   TextField,
   Typography,
 } from '@material-ui/core'
+
 import CreateAccountDialog from './CreateAccountDialog'
+import ButtonProgress from '../ButtonProgress'
 
 import {
   login,
@@ -56,9 +58,13 @@ export default function Login (props) {
   const [welcomeVisible, setWelcomeVisible] = useState(false)
   const [timeoutVar, setTimeoutVar] = useState(null)
 
+  const [loginLoading, setLoginLoading] = useState(false)
+
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
 
   const onLoginClick = async () => {
+    setLoginLoading(true)
+
     login({ username, password })
 
       .then(async ({ username, userId }) => {
@@ -81,7 +87,10 @@ export default function Login (props) {
       })
 
       // Trigger login animation chain
-      .then(() => setLoginVisible(false))
+      .then(() => {
+        setLoginLoading(false)
+        setLoginVisible(false)
+      })
 
       .catch((e) => {
         console.error(e)
@@ -89,6 +98,7 @@ export default function Login (props) {
                   type: 'snackbar',
                   severity: 'error'})
         setPassword('')
+        setLoginLoading(false)
       })
   }
 
@@ -140,6 +150,7 @@ export default function Login (props) {
           label="Username"
           value={username}
           onChange={(e) => dispatch(setUsername(e.target.value))}
+          disabled={loginLoading}
         />
       </Grid>
       <Grid item style={gridItemStyle} xs={12}>
@@ -149,6 +160,7 @@ export default function Login (props) {
           autoComplete="current-password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
+          disabled={loginLoading}
         />
       </Grid>
       <Grid item style={gridItemStyle} xs={12}>
@@ -157,8 +169,12 @@ export default function Login (props) {
           color="primary"
           variant="contained"
           onClick={onLoginClick}
+          disabled={loginLoading}
         >
-          Login
+          {loginLoading ?
+          <ButtonProgress/> :
+          "Login"
+          }
         </Button>
       </Grid>
       {/* TODO: Could add nice lilttle divider, but would need to mess with CSS */}
@@ -171,6 +187,7 @@ export default function Login (props) {
           color="secondary"
           onClick={onRegisterClick}
           className={classes.registerButton}
+          disabled={loginLoading}
         >
           Register
         </Button>

--- a/src/components/account/Login.jsx
+++ b/src/components/account/Login.jsx
@@ -47,6 +47,7 @@ const useStyles = makeStyles((theme) => ({
 export default function Login (props) {
   const classes = useStyles()
   const dispatch = useDispatch()
+  const passwordRef = useRef(null)
 
   const { addAlert } = useAlert()
 
@@ -62,7 +63,7 @@ export default function Login (props) {
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
 
-  const onLoginClick = async () => {
+  const onLoginClick = useCallback(async () => {
     setLoginLoading(true)
 
     login({ username, password })
@@ -100,7 +101,7 @@ export default function Login (props) {
         setPassword('')
         setLoginLoading(false)
       })
-  }
+  }, [dispatch, addAlert, password, username, setLoginLoading])
 
   // Login and welcome transition handling
   useEffect(() => {
@@ -131,6 +132,16 @@ export default function Login (props) {
     setCreateDialogOpen(false)
   }, [ addAlert, setCreateDialogOpen ])
 
+  const onPassKeypress = useCallback((e) => {
+    const enterPressed = e.keyCode === 13
+    if (enterPressed) onLoginClick()
+  }, [onLoginClick])
+
+  const onUsernameKeypress = useCallback((e) => {
+    const enterPressed = e.keyCode === 13
+    if (enterPressed) passwordRef.current.focus()
+  }, [passwordRef])
+
   // TODO: Move these to material-ui's makeStyle syntax
   const gridItemStyle = { textAlign: 'center', paddingBottom: '10px' }
 
@@ -150,6 +161,7 @@ export default function Login (props) {
           label="Username"
           value={username}
           onChange={(e) => dispatch(setUsername(e.target.value))}
+          onKeyDown={onUsernameKeypress}
           disabled={loginLoading}
         />
       </Grid>
@@ -157,9 +169,11 @@ export default function Login (props) {
         <TextField
           label="Password"
           type="password"
+          inputRef={passwordRef}
           autoComplete="current-password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
+          onKeyDown={onPassKeypress}
           disabled={loginLoading}
         />
       </Grid>

--- a/src/components/user/chat/ChatInput.jsx
+++ b/src/components/user/chat/ChatInput.jsx
@@ -82,7 +82,12 @@ export default function ChatInput (props) {
   }
   const onChatChange = (e) => {
     const newText = e.target.value
-    if (!newText.endsWith('\n')) setText(newText)
+
+    // If we hit enter, let onChatKeypress handle the event
+    const textAdded = newText.length > text.length
+    const enterPressed = textAdded && newText.endsWith('\n')
+
+    if (!enterPressed) setText(newText)
   }
 
   return (


### PR DESCRIPTION
## Overview

This PR adds a few details for clarity and better UX:

- **Login Screen**
    - Hitting "Enter" while typing the username shifts focus to password
    - Hitting "Enter" while typing the password logs in
    - Logging in disables inputs and shows loading animation
- **Chat**
    - Hitting "Enter" while typing a message sends a message
    - Hitting "Shift+Enter" while typing a message adds a newline to your message
    - Sending a message disables the chat bar until server responds, after which the chat bar is re-enabled and re-focused

## Issues
- Closes #21 
- Closes #35 