### PR TITLE
Integrate Spotify profile picture syncing with server

### DIFF
--- a/src/components/AppTabBar.jsx
+++ b/src/components/AppTabBar.jsx
@@ -72,11 +72,6 @@ export default function VerticalTabBar (props) {
 
   const onLinkSpotifySuccess = () => {
     setLinkSpotifyDialogOpen(false)
-    addAlert({
-      severity: 'success',
-      text: 'Your Spotify account has been linked! You can now use the Meetify services.',
-      type: 'dialog',
-    })
   }
   const onLinkSpotifyCancel = () => {
     setLinkSpotifyDialogOpen(false)

--- a/src/components/account/EditProfileDialog.jsx
+++ b/src/components/account/EditProfileDialog.jsx
@@ -59,7 +59,6 @@ export default function EditProfileDialog(props) {
   const classes = useStyles()
   const [ descChange, setDescChange ] = useState(null)
   const [ dispNameChange, setDispNameChange ] = useState(null)
-  const [ profPicChange, setProfPicChange ] = useState(null)
 
   const dispNameError = dispNameChange !== null && dispNameChange.length === 0
 
@@ -68,7 +67,6 @@ export default function EditProfileDialog(props) {
     if (open === true) {
       setDescChange(null)
       setDispNameChange(null)
-      setProfPicChange(null)
     }
   }, [open])
 
@@ -78,7 +76,6 @@ export default function EditProfileDialog(props) {
     const changeObj = {}
     if (descChange !== null) changeObj.description = descChange.trim()
     if (dispNameChange !== null) changeObj.displayName = dispNameChange.trim()
-    if (profPicChange !== null) changeObj.profilePicUrl = profPicChange.trim()
 
     onSave(changeObj)
   }
@@ -96,17 +93,17 @@ export default function EditProfileDialog(props) {
       <span className={classes.avatarRow}>
         <UserAvatar
           className={classes.avatar}
-          src={profPicChange !== null ? profPicChange : profilePicUrl}
+          src={profilePicUrl}
           displayName={dispNameChange !== null ? dispNameChange : displayName}
         />
         {/* TODO: Image upload button? Paste button? */}
         <TextField
           className={classes.avatarTextField}
           fullWidth
+          disabled
           variant="outlined"
-          label="Profile Picture URL"
-          value={profPicChange !== null ? profPicChange : profilePicUrl}
-          onChange={(e) => setProfPicChange(e.target.value)}
+          label="Profile Picture"
+          value="(This is pulled from your Spotify account)"
         />
       </span>
       <TextField

--- a/src/components/account/LinkSpotifyDialog.jsx
+++ b/src/components/account/LinkSpotifyDialog.jsx
@@ -11,10 +11,13 @@ import useAlert from '../../hooks/useAlert'
 import {
   linkSpotifyAccount,
   waitUntilSpotifyLinked,
+  syncProfilePic,
+  getProfile,
 } from '../../server'
 
 import {
   setSpotifyLinked,
+  setProfile,
 } from './accountSlice'
 
 import {
@@ -77,8 +80,27 @@ export default function LinkSpotifyDialog(props) {
   const onLinkButtonClick = () => {
     waitUntilSpotifyLinked.start({ userId })
       .then(({ spotifyLinked }) => {
-        console.log('success!')
         dispatch(setSpotifyLinked(spotifyLinked))
+        addAlert({
+          severity: 'success',
+          text: 'Your Spotify account has been linked! You can now use the Meetify services.',
+          type: 'snackbar',
+        })
+
+        // Attempt to update profile, but don't error entire process if not needed
+        return syncProfilePic()
+          .then(() => getProfile({ userId }))
+          .then((profile) => {
+            dispatch(setProfile(profile))
+          })
+          .catch((e) => {
+            console.error(e)
+            addAlert({
+              severity: 'warning',
+              text: 'Your Spotify account has been linked, but we could not retrieve your profile picture.',
+              type: 'snackbar',
+            })
+          })
       })
       .catch((e) => {
         console.error(e)

--- a/src/components/account/LogoutDialog.jsx
+++ b/src/components/account/LogoutDialog.jsx
@@ -30,7 +30,6 @@ export default function LogoutDialog (props) {
   } = props
 
   const onSubmit = () => {
-    console.log('submitting')
     logout()
       .then(() => {
         dispatch(setLoggedIn(false))

--- a/src/server.js
+++ b/src/server.js
@@ -34,7 +34,8 @@ const ENDPOINTS = {
   rejectMatch: ['matching', 'reject-match'],
   acceptMatch: ['matching', 'accept-match'],
   messages: ['chat', 'messages?match={match_id}'],
-  userSongIntersection: ['intersection', 'liked-songs']
+  userSongIntersection: ['intersection', 'liked-songs'],
+  syncProfilePic: ['user', 'update-profile-pic'],
 }
 
 // === INTERVAL(S) ===
@@ -108,7 +109,13 @@ export const login = async ({ username, email, password }) => {
         username: r.data.username,
         userId: r.data.id,
       }
-    }).catch((e) => {
+    })
+    // Do any necessary synchronizations
+    .then(async (user) => {
+      await syncProfilePic()
+      return user
+    })
+    .catch((e) => {
       throw e
     })
 }
@@ -430,6 +437,20 @@ export const getUserSongIntersection = ({ userId }) => {
       else if (!r.data)
         throw Error('Received no data from server')
       else return Object.keys(r.data).map(k => ({...r.data[k], songId: k}))
+    })
+    .catch((e) => {
+      throw e
+    })
+}
+
+export const syncProfilePic = () => {
+  const urlPath = joinUrl(SERVER_URL, ...ENDPOINTS.syncProfilePic)
+
+  return axios.get(urlPath)
+    .then((r) => {
+      if (r.status >= 300)
+        throw Error(`Received status ${r.status} from server`)
+      else return
     })
     .catch((e) => {
       throw e

--- a/src/server.js
+++ b/src/server.js
@@ -110,11 +110,6 @@ export const login = async ({ username, email, password }) => {
         userId: r.data.id,
       }
     })
-    // Do any necessary synchronizations
-    .then(async (user) => {
-      await syncProfilePic()
-      return user
-    })
     .catch((e) => {
       throw e
     })


### PR DESCRIPTION
## Overview

This PR integrates the new feature introduced by [this front end PR](https://github.com/RobBoeckermann/Meetify/pull/50), which allows the profile picture to be pulled directly from the user's Spotify account.

## Specific Changes

- Syncs profile picture on each login *(and refactored login process a bit)*
- Syncs profile picture on initial Spotify account link
- Disables profile picture editing when editing profile:  
  ![image](https://user-images.githubusercontent.com/32147527/110650744-cd9bb080-8188-11eb-8386-a4e38561073a.png)

## To Test...

If possible, please test **on login**...

1. Remove profile picture from database
2. Login as normal
3. Check that profile picture is set in db and loaded in front-end

.. and **on Spotify account link**...

1. Unlink Spotify account & remove profile picture from database
2. Login as normal; verify Spotify is unlinked and profile picture not present
3. Link Spotify account via bottom left button
4. Verify profile picture is immediately updated
