### PR TITLE
Integrate the Intersect page with the server

### DIFF
--- a/src/components/SongTileList.jsx
+++ b/src/components/SongTileList.jsx
@@ -1,0 +1,40 @@
+/*
+ * Brief, stylized, memoized wrapper for a list of SongTiles
+ *
+ * Memoizing ensures this doesn't re-render if the song list remains the same,
+ * preventing lag when used
+ */
+
+import React from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+
+import SongTile from './SongTile'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    height: '100%',
+    width: '100%',
+  },
+  songTile: {
+    height: theme.tile.height,
+    width: '100%',
+    padding: theme.spacing(1),
+  },
+}))
+
+const SongList = React.memo(({ songs }) => {
+  const classes = useStyles()
+
+  return songs.map((row, index) => (
+    <div className={classes.songTile} key={index}>
+      <SongTile
+        song={row.song}
+        artist={row.artist}
+        /* album={row.album} */
+        albumArtUrl={row.albumArtUrl}
+      />
+    </div>
+  ))
+})
+
+export default SongList

--- a/src/components/intersect/Intersect.jsx
+++ b/src/components/intersect/Intersect.jsx
@@ -4,7 +4,7 @@
  * (NOTE: Currently just contains test data)
  */
 
-import React from 'react'
+import React, { useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import useAlert from '../../hooks/useAlert'
 import { makeStyles } from '@material-ui/core/styles'
@@ -15,7 +15,9 @@ import { getUserSongIntersection } from '../../server'
 import Button from '@material-ui/core/Button'
 import TextField from '@material-ui/core/TextField'
 import Grid from '@material-ui/core/Grid'
-import SongTile from '../SongTile';
+
+import SongTile from '../SongTile'
+import ButtonProgress from '../ButtonProgress'
 
 const useStyles = makeStyles((theme) => ({
   songTile: {
@@ -30,22 +32,27 @@ export default function Intersect (props) {
   const dispatch = useDispatch()
   const { addAlert } = useAlert()
 
-  // Use state primarily to maintain an internal "cache" when this gets unmounted
+  const [loading, setLoading] = useState(false)
+
+  // Use store primarily to maintain an internal "cache" when this gets unmounted
   const username = useSelector(state => state.intersect.username)
   const songs = useSelector(state => state.intersect.songs)
 
-  const submitDisabled = !username
+  const submitDisabled = !username || loading
+  const textDisabled = loading
 
   const handleSubmit = () => {
     if (submitDisabled) return
 
     dispatch(setSongs([]))
-    // TODO: Reload animation on button
+    setLoading(true)
     getUserSongIntersection({ username })
       .then((songs) => {
+        setLoading(false)
         dispatch(setSongs(songs))
       })
       .catch((e) => {
+        setLoading(false)
         console.error(e)
         addAlert({
           type: 'snackbar',
@@ -67,6 +74,7 @@ export default function Intersect (props) {
             label="Other User's Username"
             variant="outlined"
             value={username}
+            disabled={textDisabled}
             onChange={e => dispatch(setIntersectUsername(e.target.value))}
           />
         </Grid>
@@ -78,7 +86,10 @@ export default function Intersect (props) {
             disabled={submitDisabled}
             onClick={() => handleSubmit()}
           >
-            Submit
+            { !loading ?
+              "Submit" :
+              <ButtonProgress/>
+            }
           </Button>
         </Grid>
       </Grid>

--- a/src/components/intersect/Intersect.jsx
+++ b/src/components/intersect/Intersect.jsx
@@ -7,7 +7,6 @@
 import React, { useState, useRef } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import useAlert from '../../hooks/useAlert'
-import { makeStyles } from '@material-ui/core/styles'
 
 import { setIntersectUsername, setSongs } from './intersectSlice'
 import { getUserSongIntersection } from '../../server'
@@ -16,19 +15,10 @@ import Button from '@material-ui/core/Button'
 import TextField from '@material-ui/core/TextField'
 import Grid from '@material-ui/core/Grid'
 
-import SongTile from '../SongTile'
+import SongTileList from '../SongTileList'
 import ButtonProgress from '../ButtonProgress'
 
-const useStyles = makeStyles((theme) => ({
-  songTile: {
-    height: theme.tile.height,
-    width: '100%',
-    padding: '8px',
-  }
-}))
-
 export default function Intersect (props) {
-  const classes = useStyles()
   const dispatch = useDispatch()
   const { addAlert } = useAlert()
   const textRef = useRef(null)
@@ -36,8 +26,6 @@ export default function Intersect (props) {
   const [loading, setLoading] = useState(false)
 
   // Use store primarily to maintain an internal "cache" when this gets unmounted
-  // TODO: Perhaps make this a useState and dispatch on submit, since it's a bit
-  //       laggy when typing fast
   const username = useSelector(state => state.intersect.username)
   const songs = useSelector(state => state.intersect.songs)
 
@@ -111,16 +99,7 @@ export default function Intersect (props) {
       {/* TODO: Make scrollable, e.g.... */}
       {/* <div style={{ overflowY: 'auto', height: '200px' }}> */}
       <div>
-        {songs.map((row, index) => (
-          <div className={classes.songTile} key={index}>
-            <SongTile
-              song={row.song}
-              artist={row.artist}
-              /* album={row.album} */
-              albumArtUrl={row.albumArtUrl}
-            />
-          </div>
-        ))}
+        <SongTileList songs={songs}/>
       </div>
     </div>
   );

--- a/src/components/intersect/Intersect.jsx
+++ b/src/components/intersect/Intersect.jsx
@@ -9,7 +9,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import useAlert from '../../hooks/useAlert'
 import { makeStyles } from '@material-ui/core/styles'
 
-import { setUsername, setSongs } from './intersectSlice'
+import { setIntersectUsername, setSongs } from './intersectSlice'
 import { getUserSongIntersection } from '../../server'
 
 import Button from '@material-ui/core/Button'
@@ -67,7 +67,7 @@ export default function Intersect (props) {
             label="Other User's Username"
             variant="outlined"
             value={username}
-            onChange={e => dispatch(setUsername(e.target.value))}
+            onChange={e => dispatch(setIntersectUsername(e.target.value))}
           />
         </Grid>
         <Grid item>

--- a/src/components/intersect/Intersect.jsx
+++ b/src/components/intersect/Intersect.jsx
@@ -4,7 +4,7 @@
  * (NOTE: Currently just contains test data)
  */
 
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import useAlert from '../../hooks/useAlert'
 import { makeStyles } from '@material-ui/core/styles'
@@ -31,10 +31,13 @@ export default function Intersect (props) {
   const classes = useStyles()
   const dispatch = useDispatch()
   const { addAlert } = useAlert()
+  const textRef = useRef(null)
 
   const [loading, setLoading] = useState(false)
 
   // Use store primarily to maintain an internal "cache" when this gets unmounted
+  // TODO: Perhaps make this a useState and dispatch on submit, since it's a bit
+  //       laggy when typing fast
   const username = useSelector(state => state.intersect.username)
   const songs = useSelector(state => state.intersect.songs)
 
@@ -60,6 +63,14 @@ export default function Intersect (props) {
           text: 'Could not retrieve songs. Make sure the username is correct and try again!',
         })
       })
+      .finally(() => {
+        textRef.current.focus()
+      })
+  }
+
+  const onKeypress = (e) => {
+    const enterPressed = e.keyCode === 13
+    if (enterPressed) handleSubmit()
   }
 
   return (
@@ -76,6 +87,9 @@ export default function Intersect (props) {
             value={username}
             disabled={textDisabled}
             onChange={e => dispatch(setIntersectUsername(e.target.value))}
+            onKeyDown={onKeypress}
+            inputRef={textRef}
+            autoFocus
           />
         </Grid>
         <Grid item>

--- a/src/components/intersect/intersectSlice.jsx
+++ b/src/components/intersect/intersectSlice.jsx
@@ -15,7 +15,7 @@ export const intersectSlice = createSlice({
     songs: [],
   },
   reducers: {
-    setUsername: (state, action) => {
+    setIntersectUsername: (state, action) => {
       state.username = action.payload
     },
     setSongs: (state, action) => {
@@ -27,5 +27,5 @@ export const intersectSlice = createSlice({
   }
 })
 
-export const { setUsername, setSongs, resetIntersectData } = intersectSlice.actions
+export const { setIntersectUsername, setSongs, resetIntersectData } = intersectSlice.actions
 export default intersectSlice.reducer

--- a/src/components/intersect/intersectSlice.jsx
+++ b/src/components/intersect/intersectSlice.jsx
@@ -6,73 +6,26 @@
  * Sends to state.intersect
  */
 
-// import { getPlaylistIntersect } from './server';
-
 import { createSlice } from '@reduxjs/toolkit'
-export const TEST_SONG_DATA = [
-  {
-    song: 'Welcome to the Black Parade',
-    artist: 'My Chemical Romance',
-    album: 'The Black Parade',
-    albumArtUrl: 'https://upload.wikimedia.org/wikipedia/en/c/c7/Welcome_to_the_Black_Parade_cover.jpg',
-  },
-  {
-    song: 'still feel.',
-    artist: 'half alive',
-    album: 'still feel.',
-    albumArtUrl: 'https://images.genius.com/024425b1a9cd97a94ca44950e780c138.1000x1000x1.jpg',
-  },
-  {
-    song: 'Ramen King',
-    artist: 'Pink Guy',
-    album: 'Pink Season',
-    albumArtUrl: 'https://upload.wikimedia.org/wikipedia/en/8/8b/Pink_Season.jpg',
-  },
-]
 
 export const intersectSlice = createSlice({
   name: 'account',
   initialState: {
-    userId: '',
+    username: '',
     songs: [],
   },
   reducers: {
-    setUserId: (state, action) => {
-      state.userId = action.payload
+    setUsername: (state, action) => {
+      state.username = action.payload
     },
     setSongs: (state, action) => {
       state.songs = action.payload
     },
-    importSongs: (state, action) => {
-      // const user1 = action.payload.user1
-      // const user2 = action.payload.user2
-
-      // NOTE: Original test data; can make more robust or delete later
-      // getPlaylistIntersect(user1, user2).then((r) => {
-      //   // TODO: Clean this up
-      //   if (r.data) {
-      //     if (r.data.data) {
-      //       this.props.onUpdate({songs: r.data.data});
-      //     } else {
-      //       console.error('Invalid format', r);
-      //     }
-      //   } else {
-      //     console.error('Invalid format', r);
-      //   }
-      // }).catch((e) => {
-      //   console.log(e);
-      // });
-
-      // NOTE: Import temporary test data
-      state.songs = TEST_SONG_DATA
-        .concat(TEST_SONG_DATA)
-        .concat(TEST_SONG_DATA)
-    },
     resetIntersectData: state => {
-      state = { userId: '', songs: [] }
-    }
+      state = { username: '', songs: [] }
+    },
   }
 })
 
-export const { setUserId, setSongs, importSongs, resetIntersectData } = intersectSlice.actions
+export const { setUsername, setSongs, resetIntersectData } = intersectSlice.actions
 export default intersectSlice.reducer

--- a/src/components/user/UserView.jsx
+++ b/src/components/user/UserView.jsx
@@ -28,7 +28,7 @@ import SongsIcon from '@material-ui/icons/LibraryMusic'
 
 import ChatView from './chat/ChatView'
 import Account from '../account/Account'
-import SongTile from '../SongTile'
+import SongTileList from '../SongTileList'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -46,11 +46,6 @@ const useStyles = makeStyles((theme) => ({
   appBar: {
     position: 'absolute',
     top: 0,
-  },
-  songTile: {
-    height: theme.tile.height,
-    width: '100%',
-    padding: '8px',
   },
   title: {
     flexGrow: 1,
@@ -91,15 +86,7 @@ export default function UserView (props) {
         No matching songs found
       </Typography>
       :
-      songs.map((row, index) => (
-        <div className={classes.songTile} key={index}>
-          <SongTile
-            song={row.song}
-            artist={row.artist}
-            albumArtUrl={row.albumArtUrl}
-          />
-        </div>
-      )),
+      <SongTileList songs={songs}/>
   }, {
     val: 'chat',
     icon: <ChatIcon/>,

--- a/src/server.js
+++ b/src/server.js
@@ -34,7 +34,10 @@ const ENDPOINTS = {
   rejectMatch: ['matching', 'reject-match'],
   acceptMatch: ['matching', 'accept-match'],
   messages: ['chat', 'messages?match={match_id}'],
-  userSongIntersection: ['intersection', 'liked-songs'],
+  userSongIntersection: {
+    byUserId: ['intersection', 'liked-songs'],
+    byUsername: ['intersection', 'liked-songs-by-username'],
+  },
   syncProfilePic: ['user', 'update-profile-pic'],
 }
 
@@ -419,11 +422,14 @@ export const acceptMatch = ({ matchId }) => {
     })
 }
 
-export const getUserSongIntersection = ({ userId }) => {
-  const urlPath = joinUrl(SERVER_URL, ...ENDPOINTS.userSongIntersection)
-  const dataToSend = {
+export const getUserSongIntersection = ({ userId, username }) => {
+  const endpointKey = userId != null ? 'byUserId' : 'byUsername'
+  const urlPath = joinUrl(SERVER_URL, ...ENDPOINTS.userSongIntersection[endpointKey])
+
+  const dataToSend = cleanEmptyKeys({
     'target_user_id': userId,
-  }
+    'target_username': username,
+  })
 
   return axios.post(urlPath, dataToSend)
     .then((r) => {


### PR DESCRIPTION
## Overview

This PR integrates the `intersection/liked-songs-by-username` endpoint with the front-end for use on the Intersect page. To fit this, some verbiage was changed since the front-end previously took User ID in this area.

In the future, this page will likely change quite a bit and be made more robust since we want additional features (intersecting any two playlists, saving playlists, etc.), but I think it's best to keep the page as originally designed for now. This will allow me to make a **v1.0.0 release** following this PR, since **this is the last of the core logic to be integrated**. Then going forward we can add and modify as needed since we (hopefully) won't have breaking changes between versions anyway.

## Issues

- Closes #5 