### PR TITLE
Fix timing issue where chat could refresh forever

### DIFF
--- a/src/asyncInterval.js
+++ b/src/asyncInterval.js
@@ -1,0 +1,41 @@
+/*
+ * Replacement for setInterval for utilizing async functions, waiting for the
+ * previous iteration to finish before running again
+ *
+ * Has same interaction as setInterval, e.g.:
+ *   import { setAsyncInterval, clearAsyncInterval } from './asyncInterval'
+ *   const interval = setAsyncInterval(myFunc, 1000)
+ *   clearAsyncInterval(interval)
+ */
+
+export const setAsyncInterval = (func, ms) => {
+  const intervalObj = {
+    run: true,
+    ref: null,
+  }
+
+  const intervalMethod = async () => {
+    // "run" key makes sure that no timing issues can happen causing
+    // clearTimeout to not happen
+    if (!intervalObj.run) return
+
+    func()
+      .then(() => {
+        intervalObj.ref = setTimeout(intervalMethod, ms)
+      })
+      .catch(() => {
+        clearAsyncInterval(intervalObj)
+      })
+  }
+
+  intervalMethod()
+  return intervalObj
+}
+
+export const clearAsyncInterval = (intervalObj) => {
+  intervalObj.run = false
+  clearTimeout(intervalObj.ref)
+}
+
+const defaultExport = { setAsyncInterval, clearAsyncInterval }
+export default defaultExport

--- a/src/components/user/UserView.jsx
+++ b/src/components/user/UserView.jsx
@@ -60,6 +60,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
+let runInterval = false
+
 export default function UserView (props) {
   const classes = useStyles()
 
@@ -121,9 +123,11 @@ export default function UserView (props) {
   // (This also allows the first call to be instant!)
   useEffect(() => {
     if (refreshMethod) {
+      runInterval = true
       let timeout = null
 
       const intervalMethod = async () => {
+        if (!runInterval) return
         refreshMethod({ matchId })
           .then(() => {
             timeout = setTimeout(intervalMethod, 1000)
@@ -134,7 +138,10 @@ export default function UserView (props) {
       }
 
       intervalMethod()
-      return () => clearTimeout(timeout)
+      return () => {
+        runInterval = false
+        clearTimeout(timeout)
+      }
     }
   }, [ refreshMethod, matchId ])
 


### PR DESCRIPTION
## Forward

@RobBoeckermann @jsteuver this change is a bit technical, so no worries if you don't understand it or its implications. I mainly wanted a PR to help track the issue, but I'll keep it open for a little while in case you guys want to test it out!

## Issue Resolution

### Problem

On the Matches page, if timed properly, you could exit a user's "window" and not properly cancel the chat refreshes, causing them to forever run in the background.

### Reason

To regularly refresh, we use an infinite loop with `setTimeout`, which delays the calls to our refresh method so we don't overload the server.

The timing issue itself is kind of inevitable because there will always be some downtime when the previous iteration finished and the next hasn't started, meaning the `timeout` variable used for stopping the loop is not yet set and cannot be cancelled. Then when we exit the page, we lose our reference to the `timeout` object and cannot cancel it at all, causing the infinite loop.

### Solution

1. Added a flag check within each interval iteration in case timing issue is hit
2. *(For cleanliness...)* Refactored area into generic, reusable methods under `asyncInterval.js`

## To Test...

1. Hit "Ctrl+Shift+i" to open the developer console
2. In the Matches page, open any user's window
3. Watch the console to see the `Refreshing match x data...` messages
4. Mess with the UI to make sure those console messages stop (exit the window, change tabs, etc.)

## Issues

- Closes #31 
