### PR TITLE
Add default profile description when user doesn't have one set

### DIFF
--- a/src/components/account/Account.jsx
+++ b/src/components/account/Account.jsx
@@ -14,6 +14,7 @@
 
 import React, { useCallback, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { makeStyles } from '@material-ui/core/styles'
 import useAlert from '../../hooks/useAlert'
 
 import { setProfile } from './accountSlice'
@@ -41,6 +42,12 @@ const MARGIN = '8px'
 const HEADER_GRADIENT = theme.getGradient([theme.palette.background.default, theme.palette.primary.dark])
 const BODY_GRADIENT = theme.getGradient([theme.palette.background.default, theme.palette.secondary.dark])
 
+const useStyles = makeStyles((theme) => ({
+  description: {
+    whiteSpace: 'pre', // Allow new lines
+  }
+}))
+
 // == TEMP TEST STUFF ==
 
 const PROFILE_IMG_SIZE = theme.images.squareImageHeight
@@ -49,9 +56,11 @@ const PROFILE_IMG_SIZE = theme.images.squareImageHeight
 
 // TODO: Rename to Profile (account settings could & should be separate!)
 export default function Account (props) {
-  const userId = useSelector(state => state.account.userId)
+  const classes = useStyles()
   const dispatch = useDispatch()
   const { addAlert } = useAlert()
+
+  const userId = useSelector(state => state.account.userId)
 
   const {
     username,
@@ -142,8 +151,10 @@ export default function Account (props) {
           <Typography variant="h6">
             Personal Description
           </Typography>
-          <Typography variant="body1">
-            {profile.description}
+          <Typography
+            variant="body1"
+            className={classes.description}
+          >
           </Typography>
         </Card>
       </Grid>

--- a/src/components/account/Account.jsx
+++ b/src/components/account/Account.jsx
@@ -45,7 +45,10 @@ const BODY_GRADIENT = theme.getGradient([theme.palette.background.default, theme
 const useStyles = makeStyles((theme) => ({
   description: {
     whiteSpace: 'pre', // Allow new lines
-  }
+  },
+  hintText: {
+    color: theme.palette.text.hint
+  },
 }))
 
 // == TEMP TEST STUFF ==
@@ -153,8 +156,11 @@ export default function Account (props) {
           </Typography>
           <Typography
             variant="body1"
-            className={classes.description}
+            className={`${classes.description} ${!profile.description ? classes.hintText : ''}`}
           >
+            {
+              profile.description || '(no description)'
+            }
           </Typography>
         </Card>
       </Grid>


### PR DESCRIPTION
## Overview

When a user has no profile description, you will now see the following:

![image](https://user-images.githubusercontent.com/32147527/111074022-a1996b80-84b7-11eb-8c39-dd82768f9ce7.png)

While I was here, I also added the apparently missing capability for the description to display newlines

## Issues

- Closes #23 